### PR TITLE
Add kwargs passthrough to proxy_exact_request

### DIFF
--- a/wsgiproxy/exactproxy.py
+++ b/wsgiproxy/exactproxy.py
@@ -41,7 +41,7 @@ def filter_paste_httpserver_proxy_environ(environ):
         environ['SERVER_PORT'] = port
 
 
-def proxy_exact_request(environ, start_response):
+def proxy_exact_request(environ, start_response, kwargs={}):
     """
     HTTP proxying WSGI application that proxies the exact request
     given in the environment.  All controls are passed through the
@@ -60,7 +60,7 @@ def proxy_exact_request(environ, start_response):
     else:
         raise ValueError(
             "Unknown scheme: %r" % scheme)
-    conn = ConnClass('%(SERVER_NAME)s:%(SERVER_PORT)s' % environ)
+    conn = ConnClass('%(SERVER_NAME)s:%(SERVER_PORT)s' % environ, **kwargs)
     headers = {}
     for key, value in environ.items():
         if key.startswith('HTTP_'):


### PR DESCRIPTION
Add kwargs passthrough to proxy_exact_request to allow significantly more control over HTTP{,S}Connection objects.  This is useful for e.g. setting an alternative CA or certificate.  Can be used as follows:

```
    >>> import ssl
    >>> from wsgiproxy.exactproxy import proxy_exact_request
    >>> sslcontext = ssl.create_default_context()
    >>> # Do some stuff to the SSLContext
    ...
    >>> kwargs = {
    ...     context: sslcontext
    ... }
    >>> proxy_exact_request(environ, start_response, kwargs)
```

I needed this functionality for testing against a self-signed cert; I can't imagine I'm the only one who has ever wanted to do so.

This should possibly be added to other proxy functions; I am willing to do so if this PR is accepted.
